### PR TITLE
fix: removes comments from waybar config when parsing json

### DIFF
--- a/waymedia
+++ b/waymedia
@@ -4,25 +4,34 @@ import os
 import json
 from os.path import expanduser
 import subprocess
+import re
 
-config_path = f"{expanduser("~")}/.config/waybar"
+config_path = f"{expanduser('~')}/.config/waybar"
 
 if os.path.exists(f"{config_path}/config.jsonc"):
     config_path = f"{config_path}/config.jsonc"
 else:
-    f"{config_path}/config"
+    config_path = f"{config_path}/config"
+
+def remove_comments(jsonc_str):
+    json_str = re.sub(r'//.*', '', jsonc_str)  # remove single-line comments
+    json_str = re.sub(r'/\*.*?\*/', '', json_str, flags=re.DOTALL)  # remove multi-line comments
+    return json_str
 
 with open(config_path, "r", encoding="utf-8") as file:
-    config_json = json.loads(file.read())
+    jsonc_content = file.read()
 
-module_configs = config_json["custom/waymedia"]
-pause_icon = module_configs["pause-icon"] if "pause-icon" in module_configs else "   "
-play_icon = module_configs["play-icon"] if "play-icon" in module_configs else "   "
-divider = module_configs["divider"] if "divider" in module_configs else " - "
-format = module_configs["format"] if "format" in module_configs else "{icon}{artist}{divider}{title}"
-limit = module_configs["limit"] if "limit" in module_configs else 60
+clean_json_str = remove_comments(jsonc_content)
+config_json = json.loads(clean_json_str)
 
-def get_command_result(command)-> str:
+module_configs = config_json.get("custom/waymedia", {})
+pause_icon = module_configs.get("pause-icon", "   ")
+play_icon = module_configs.get("play-icon", "   ")
+divider = module_configs.get("divider", " - ")
+format = module_configs.get("format", "{icon}{artist}{divider}{title}")
+limit = module_configs.get("limit", 60)
+
+def get_command_result(command) -> str:
     return subprocess.run(command, shell=True, capture_output=True, text=True).stdout.strip()
 
 metadata = get_command_result("playerctl metadata") 
@@ -33,27 +42,21 @@ for player in players:
     status = get_command_result(f"playerctl status -p {player}")
 
     if status != "Stopped" and status != "":
-        icon = play_icon if status == "Paused" or status == "Paused" else pause_icon
+        icon = play_icon if status == "Paused" else pause_icon
         artist = get_command_result("playerctl metadata --format '{{artist}}'")
         title = get_command_result("playerctl metadata --format '{{title}}'")
-        
         
         if len(artist) == 0:
             divider = ""
 
-
         text = format.replace("{icon}", icon).replace("{title}", title).replace("{divider}", divider).replace("{artist}", artist).strip().replace("&", "&amp;").replace("{}", "")
-
 
         if len(text) > limit:
             text = f"{text[:limit - 3]}..."
             
-        
         print(text, flush=True)
         exit(0)
 
 print("", flush=True)
-exit(0)   
-
-
+exit(0)
 

--- a/waymedia-buttons
+++ b/waymedia-buttons
@@ -4,24 +4,32 @@ import os
 import json
 from os.path import expanduser
 import subprocess
+import re
 
 config_path = f"{expanduser("~")}/.config/waybar"
 
 if os.path.exists(f"{config_path}/config.jsonc"):
     config_path = f"{config_path}/config.jsonc"
 else:
-    f"{config_path}/config"
+    config_path = f"{config_path}/config"
+
+def remove_comments(jsonc_str):
+    json_str = re.sub(r'//.*', '', jsonc_str)  # remove single-line comments
+    json_str = re.sub(r'/\*.*?\*/', '', json_str, flags=re.DOTALL)  # remove multi-line comments
+    return json_str
 
 with open(config_path, "r", encoding="utf-8") as file:
-    config_json = json.loads(file.read())
+    jsonc_content = file.read()
+
+clean_json_str = remove_comments(jsonc_content)
+config_json = json.loads(clean_json_str)
 
 
-
-module_configs = config_json["custom/waymedia-buttons"]
-play_icon = module_configs["play-icon"] if "play-icon" in module_configs else "  "
-pause_icon = module_configs["pause-icon"] if "pause-icon" in module_configs else "  "
-skip_icon = module_configs["skip-icon"] if "skip-icon" in module_configs else " 󰒭 "
-previous_icon = module_configs["previous-icon"] if "previous-icon" in module_configs else " 󰒮 "
+module_configs = config_json.get("custom/waymedia-buttons", {})
+play_icon = module_configs.get("play-icon") if "play-icon" in module_configs else "  "
+pause_icon = module_configs.get("pause-icon") if "pause-icon" in module_configs else "  "
+skip_icon = module_configs.get("skip-icon") if "skip-icon" in module_configs else " 󰒭 "
+previous_icon = module_configs.get("previous-icon") if "previous-icon" in module_configs else " 󰒮 "
 
 def get_command_result(command)-> str:
     return subprocess.run(command, shell=True, capture_output=True, text=True).stdout.strip()
@@ -34,7 +42,7 @@ for player in players:
     status = get_command_result(f"playerctl status -p {player}")
 
     if status != "Stopped" and status != "":
-        icon = play_icon if status == "Paused" or status == "Paused" else pause_icon
+        icon = play_icon if status == "Paused" else pause_icon
         artist = get_command_result("playerctl metadata --format '{{artist}}'")
         title = get_command_result("playerctl metadata --format '{{title}}'")
         


### PR DESCRIPTION
Script breaks when there are comments in `$HOME/.config/waybar/config.jsonc`. This is a fix for that.